### PR TITLE
Fixing MetricsPort to read value from the config file

### DIFF
--- a/cmd/supervysor/start.go
+++ b/cmd/supervysor/start.go
@@ -36,7 +36,7 @@ var startCmd = &cobra.Command{
 
 		if metrics {
 			go func() {
-				err := helpers.StartMetricsServer(reg, metricsPort)
+				err := helpers.StartMetricsServer(reg, config.MetricsPort)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Seems it should have `config.MetricsPort` here. If I understand correctly `metricsPort` is used just to initialize the config, but if we would like to use that config value it should read directly from it.
Verified on my own instance.